### PR TITLE
Replicate jetson-nano sd-card layout offsets

### DIFF
--- a/assets/jetson-nano-emmc-assets/resinOS-flash.xml
+++ b/assets/jetson-nano-emmc-assets/resinOS-flash.xml
@@ -178,18 +178,7 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> EKSFILE </filename>
         </partition>
-
-        <partition name="BMP" id="19" type="data">
-            <allocation_policy> sequential </allocation_policy>
-            <filesystem_type> basic </filesystem_type>
-            <size> 81920 </size>
-            <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x8 </allocation_attribute>
-            <percent_reserved> 0 </percent_reserved>
-            <filename> bmp.blob </filename>
-        </partition>
-
-        <partition name="RP4" id="20" type="data">
+        <partition name="RP4" id="19" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -197,6 +186,18 @@
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> rp4.blob </filename>
+        </partition>
+        <!-- Size is calculated so that it matches
+             the resin device specific space
+        -->
+        <partition name="BMP" id="20" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 46971904 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> bmp.blob </filename>
         </partition>
         <partition id="21" name="resin-boot" type="data">
             <allocation_policy> sequential </allocation_policy>
@@ -210,7 +211,7 @@
         <partition id="22" name="resin-rootA" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 1019122176 </size>
+            <size> 499122176 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
@@ -219,7 +220,7 @@
         <partition id="23" name="resin-rootB" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 1019122176 </size>
+            <size> 499122176 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
@@ -228,7 +229,7 @@
         <partition id="24" name="resin-state" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 1019122176 </size>
+            <size> 20971520 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
@@ -237,7 +238,7 @@
         <partition id="25" name="resin-data" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 2019122176 </size>
+            <size> 212860928 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>

--- a/assets/jetson-nano-qspi-sd-assets/resinOS-flash.xml
+++ b/assets/jetson-nano-qspi-sd-assets/resinOS-flash.xml
@@ -178,18 +178,7 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> EKSFILE </filename>
         </partition>
-
-        <partition name="BMP" id="19" type="data">
-            <allocation_policy> sequential </allocation_policy>
-            <filesystem_type> basic </filesystem_type>
-            <size> 81920 </size>
-            <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x8 </allocation_attribute>
-            <percent_reserved> 0 </percent_reserved>
-            <filename> bmp.blob </filename>
-        </partition>
-
-        <partition name="RP4" id="20" type="data">
+        <partition name="RP4" id="19" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -197,6 +186,18 @@
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> rp4.blob </filename>
+        </partition>
+        <!-- Size is calculated so that it matches
+             the resin device specific space
+        -->
+        <partition name="BMP" id="20" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 46971904 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> bmp.blob </filename>
         </partition>
         <partition id="21" name="resin-boot" type="data">
             <allocation_policy> sequential </allocation_policy>
@@ -210,7 +211,7 @@
         <partition id="22" name="resin-rootA" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 1019122176 </size>
+            <size> 499122176 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
@@ -219,7 +220,7 @@
         <partition id="23" name="resin-rootB" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 1019122176 </size>
+            <size> 499122176 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
@@ -228,7 +229,7 @@
         <partition id="24" name="resin-state" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 1019122176 </size>
+            <size> 20971520 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
@@ -237,7 +238,7 @@
         <partition id="25" name="resin-data" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 2019122176 </size>
+            <size> 212860928 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>


### PR DESCRIPTION
Resin partitions offsets and sizes need to be the same,
both when using the flash tool and when writing the
sd-card with Etcher.

Although partition sizes specified in the xml are not important
when signing binaries - they need to be at least the size of 
the binary to be signed - they do matter when actually performing
board flashing.

Also, resin-boot  offset needs to be the same as
the corresponding RESIN_DEVICE_SPECIFIC_SPACE,
should tegra partition sizes increase in future L4T versions.