### PR TITLE
jetson-nano: Use image RP1 dtb and BMP

### DIFF
--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -65,6 +65,8 @@ module.exports = class ResinJetsonFlash {
 				partitions: {
 					LNX: { path: null },
 					DTB: { path: null },
+					RP1: { path: null },
+					BMP: { path: null },
 					'resin-boot': { path: null },
 					'resin-rootA': { path: null },
 					'resin-rootB': { path: null },
@@ -79,6 +81,8 @@ module.exports = class ResinJetsonFlash {
 				partitions: {
 					LNX: { path: null },
 					DTB: { path: null },
+					RP1: { path: null },
+					BMP: { path: null },
 					'resin-boot': { path: null },
 					'resin-rootA': { path: null },
 					'resin-rootB': { path: null },


### PR DESCRIPTION
Signed devicetree blob is being written to RP1
partition too, and will differ from one basebard
to another.

The BMP blob should come from the image too,
to prevent the BSP logo from being displayed.

Change-type: minor
Signed-off-by: Alexandru Costache <alexandru@balena.io>