### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # jetson-flash
 
-> This tool allows users to flash ResinOS on Jetson supported devices
+> This tool allows users to flash BalenaOS on Jetson supported devices
 
 This tool is separate into two parts:
 - Extract resin-image from a resin-image-flasher (this will be moved to [etcher](https://github.com/resin-io/etcher) once the fatfs issues are fixed)
 - Flash resin-image via USB on a Jetson board (this will be moved to [etcher](https://github.com/resin-io/etcher))
 
-Resin devices support
+Balena devices support
 ---------------------
 
 * Nvidia Jetson TX2
+* NVidia Jetson NANO (both sd-card and emmc versions)
+* NVidia Jetson Xavier
 
 WARNINGS
 --------
 
-Due to issues with the fatfs node module, which does not support some operations we cannot transfer the following resin configurations:
+Due to issues with the fatfs node module, which does not support some operations we cannot transfer the following Balena configurations:
 
 * system-proxy
 
@@ -27,7 +29,7 @@ Assumptions
 Prerequisites
 -------------
 
--  A Jetson ResinOS image 
+-  A Jetson BalenaOS image
 
 Tool dependencies
 -----------------
@@ -38,18 +40,20 @@ Tool dependencies
 Getting Started
 ---------------
 
-NOTE: Make sure that the Jetson board is pluged to your host via USB and is in recovery mode
-NOTE: Running the Nvidia flash tool requires sudo priviliges
-NOTE: Thist tool will produce all intermidiate steps in `/tmp/${pid_of_process}` and will require sudo priviliges to delete
+NOTES:
+ - Make sure that the Jetson board is pluged to your host via USB and is in recovery mode
+ - Running the Nvidia flash tool requires sudo priviliges
+ - This tool will produce all intermidiate steps in `/tmp/${pid_of_process}` and will require sudo priviliges to delete
+ - If flashing Jetson TX2 with a BalenaOS image older than 2.47, please checkout tag 'v0.3.0'. BalenaOS 2.47 updated L4T version from 28.3 to 32.2.
 
 Clone this repository
 ```sh
-$ git clone https://github.com/resin-os/jetson-flash.git
+$ git clone https://github.com/balena-os/jetson-flash.git
 ```
 
 Run the cli, specifying desired device type:
 ```sh
-$ ./bin/cmd.js -f resin.img -m <device_type>
+$ ./bin/cmd.js -f balena.img -m <device_type>
 ```
 
 Current supported device types are: jetson-nano-emmc, jetson-nano-qspi-sd, jetson-tx2, jetson-xavier
@@ -57,7 +61,7 @@ Current supported device types are: jetson-nano-emmc, jetson-nano-qspi-sd, jetso
 Support
 -------
 
-If you're having any problems, please [raise an issue](https://github.com/resin-io/jetson-flash/issues/new) on GitHub and the resin.io team will be happy to help.
+If you're having any problems, please [raise an issue](https://github.com/balena-os/jetson-flash/issues/new) on GitHub and the balena.io team will be happy to help.
 
 License
 -------


### PR DESCRIPTION
Update readme file to mention tags that
can be used with older L4T releases, like 28.x.

BalenaOS 2.47 uses L4T 32.2, which has a
partition layout that is incompatible with
previous L4T releases.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>