### PR TITLE
jetson: Add flashing support for L4T 32.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Run the cli, specifying desired device type:
 $ ./bin/cmd.js -f balena.img -m <device_type>
 ```
 
-Current supported device types are: jetson-nano-emmc, jetson-nano-qspi-sd, jetson-tx2, jetson-xavier
+Current supported device types are: jetson-nano-emmc, jetson-nano-qspi-sd, jetson-tx2, jetson-xavier, jetson-xavier-nx-devkit-emmc
 
 Support
 -------

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Balena devices support
 * Nvidia Jetson TX2
 * NVidia Jetson NANO (both sd-card and emmc versions)
 * NVidia Jetson Xavier
+* NVidia Jetson NX
 
 WARNINGS
 --------
@@ -44,7 +45,9 @@ NOTES:
  - Make sure that the Jetson board is pluged to your host via USB and is in recovery mode
  - Running the Nvidia flash tool requires sudo priviliges
  - This tool will produce all intermidiate steps in `/tmp/${pid_of_process}` and will require sudo priviliges to delete
- - If flashing Jetson TX2 with a BalenaOS image older than 2.47, please checkout tag 'v0.3.0'. BalenaOS 2.47 updated L4T version from 28.3 to 32.2.
+ - If flashing Jetson TX2 with a BalenaOS image older than 2.47, please checkout tag 'v0.3.0'. BalenaOS 2.47 updated L4T version from 28.3 to 32.4.2.
+ - Current BSP version used for flashing is L4T 32.4.2. Please ensure the BalenaOS version you are flashing uses the same L4T, by consulting the changelog
+   available in the [BalenaOS Jetson](https://github.com/balena-os/balena-jetson/commits/master) repository.
 
 Clone this repository
 ```sh

--- a/assets/jetson-xavier-nx-devkit-emmc-assets/resinOS-flash.xml
+++ b/assets/jetson-xavier-nx-devkit-emmc-assets/resinOS-flash.xml
@@ -597,7 +597,7 @@
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
-            <description> **Required.** Slot B; contains boot control data. </description>
+            <description> Ensures space for adding newer tegra partitions before resin-boot, in future L4T updates. </description>
         </partition>
         <partition name="resin-boot" type="data">
             <allocation_policy> sequential </allocation_policy>
@@ -611,7 +611,7 @@
         <partition name="resin-rootA" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 499122176 </size>
+            <size> 750780416 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <filename> FILENAME </filename>
@@ -620,7 +620,7 @@
         <partition name="resin-rootB" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 499122176 </size>
+            <size> 750780416 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <filename> FILENAME </filename>

--- a/assets/jetson-xavier-nx-devkit-emmc-assets/resinOS-flash.xml
+++ b/assets/jetson-xavier-nx-devkit-emmc-assets/resinOS-flash.xml
@@ -1,0 +1,658 @@
+<partition_layout version="01.00.0000">
+    <device instance="0" type="spi" sector_size="512" num_sectors="65536">
+        <partition name="BCT" type="boot_config_table">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains Boot Configuration Table (BCT). </description>
+        </partition>
+        <partition name="mb1" type="mb1_bootloader">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MB1FILE </filename>
+            <description> **Required.** Slot A; contains NVIDIA signed MB1 binary. </description>
+        </partition>
+        <partition name="mb1_b" type="mb1_bootloader">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MB1FILE </filename>
+            <description> **Required.** Slot B; contains NVIDIA signed MB1 binary. </description>
+        </partition>
+        <partition name="MB1_BCT" type="mb1_boot_config_table">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+	    <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Slot A; contains MB1 boot configuration table. </description>
+        </partition>
+        <partition name="MB1_BCT_b" type="mb1_boot_config_table">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Slot B; contains MB1 boot configuration table. </description>
+        </partition>
+        <partition name="MEM_BCT" type="mem_boot_config_table">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Slot A; contains memory configuration table. </description>
+        </partition>
+        <partition name="MEM_BCT_b" type="mem_boot_config_table">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Slot B; contains memory configuration table. </description>
+        </partition>
+        <partition name="spe-fw" type="spe_fw" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> SPEFILE </filename>
+            <description> **Required.** Slot A; contains BPMP SPE-FW binary. </description>
+        </partition>
+        <partition name="spe-fw_b" type="spe_fw" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> SPEFILE </filename>
+            <description> **Required.** Slot B; contains BPMP SPE-FW binary. </description>
+        </partition>
+        <partition name="mb2" type="mb2_bootloader" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TEGRABOOT </filename>
+            <description> **Required.** Slot A; contains TegraBoot binary. </description>
+        </partition>
+        <partition name="mb2_b" type="mb2_bootloader" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TEGRABOOT </filename>
+            <description> **Required.** Slot B; contains TegraBoot binary. </description>
+        </partition>
+        <partition name="mts-preboot" type="mts_preboot" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MTSPREBOOT </filename>
+            <description> **Required.** Slot A; contains Denver preboot firmware. </description>
+        </partition>
+        <partition name="mts-preboot_b" type="mts_preboot" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MTSPREBOOT </filename>
+            <description> **Required.** Slot B; contains Denver preboot firmware. </description>
+
+        </partition>
+        <partition name="mts-mce" type="mts_mce" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MTS_MCE </filename>
+            <description> **Required.** Slot A; contains microcode associated with boot, power management,
+              and clocks. </description>
+        </partition>
+        <partition name="mts-mce_b" type="mts_mce" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MTS_MCE </filename>
+            <description> **Required.** Slot B; contains microcode associated with boot, power management,
+              and clocks. </description>
+        </partition>
+        <partition name="mts-proper" type="mts_proper" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 4194304 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MTSPROPER </filename>
+            <description> **Required.** Slot A; contains microcode associated with execution
+              and optimization of ARM code. </description>
+        </partition>
+        <partition name="mts-proper_b" type="mts_proper" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 4194304 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MTSPROPER </filename>
+            <description> **Required.** Slot B; contains microcode associated with execution
+              and optimization of ARM code. </description>
+        </partition>
+        <partition name="sc7" type="WB0" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> WB0BOOT </filename>
+            <description> **Required.** Slot A; contains warm boot firmware. </description>
+        </partition>
+        <partition name="sc7_b" type="WB0" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> WB0BOOT </filename>
+            <description> **Required.** Slot B; contains warm boot firmware. </description>
+        </partition>
+        <partition name="SMD" type="smd">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 4096 </size>
+            <align_boundary> 65536 </align_boundary>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> slot_metadata.bin </filename>
+            <description> **Required.** Slot A; contains slot status for A/B boot and A/B
+              update. </description>
+        </partition>
+        <partition name="SMD_b" type="smd">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 4096 </size>
+            <align_boundary> 65536 </align_boundary>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> slot_metadata.bin </filename>
+            <description> **Required.** Slot B; contains slot status for A/B boot and A/B
+              update. </description>
+        </partition>
+        <partition name="xusb-fw" type="xusb_fw">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <align_boundary> 65536 </align_boundary>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> xusb_sil_rel_fw </filename>
+            <description> **Required.** Slot A; contains XUSB module’s firmware file, making XUSB
+              a true USB 3.0 compliant host controller. </description>
+        </partition>
+        <partition name="xusb-fw_b" type="xusb_fw">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> xusb_sil_rel_fw </filename>
+            <description> **Required.** Slot B; contains XUSB module’s firmware file, making XUSB
+              a true USB 3.0 compliant host controller. </description>
+        </partition>
+        <partition name="cpu-bootloader" type="bootloader" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 1441792 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TBCFILE </filename>
+            <description> **Required.** Slot A; contains CBoot, the final boot stage CPU Bootloader
+              binary that loads the binary in the kernel partition.  </description>
+        </partition>
+        <partition name="cpu-bootloader_b" type="bootloader" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 1441792 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TBCFILE </filename>
+            <description> **Required.** Slot B; contains CBoot, the final boot stage CPU Bootloader
+              binary that loads the binary in the kernel partition.  </description>
+        </partition>
+        <partition name="bootloader-dtb" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 458752 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TBCDTB-FILE </filename>
+            <description> **Required.** Slot A; contains Bootloader device tree blob
+              (DTB). </description>
+        </partition>
+        <partition name="bootloader-dtb_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 458752 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TBCDTB-FILE </filename>
+            <description> **Required.** Slot B; contains Bootloader device tree blob
+              (DTB). </description>
+        </partition>
+        <partition name="BMP" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> bmp.blob </filename>
+            <description> **Optional.** Slot A; contains BMP images for splash screen display during
+              boot. </description>
+        </partition>
+        <partition name="BMP_b" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> bmp.blob </filename>
+            <description> **Optional.** Slot B; contains BMP images for splash screen display during
+              boot. </description>
+        </partition>
+        <partition name="secure-os" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 2621440 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TOSFILE </filename>
+            <description> **Required.** Slot A; contains the trusted OS. </description>
+        </partition>
+        <partition name="secure-os_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 2621440 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TOSFILE </filename>
+            <description> **Required.** Slot B; contains the trusted OS. </description>
+        </partition>
+        <partition name="eks" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> EKSFILE </filename>
+            <description> **Optional.** Slot A; contains the encrypted keys. </description>
+        </partition>
+        <partition name="eks_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> eks.img </filename>
+            <description> **Optional.** Slot B; contains the encrypted keys. </description>
+        </partition>
+        <partition name="adsp-fw" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 1048576 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> adsp-fw.bin </filename>
+            <description> **Required.** Slot A; contains ADSP software. </description>
+        </partition>
+        <partition name="adsp-fw_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 1048576 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> adsp-fw.bin </filename>
+            <description> **Required.** Slot B; contains ADSP software. </description>
+        </partition>
+        <partition name="rce-fw" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 1048576 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> CAMERAFW </filename>
+            <description> **Required.** Slot A; contains `camera-rtcpu-rce` firmware. </description>
+        </partition>
+        <partition name="rce-fw_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 1048576 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> CAMERAFW </filename>
+            <description> **Required.** Slot B; contains `camera-rtcpu-rce` firmware. </description>
+        </partition>
+        <partition name="sce-fw" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 1048576 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+<!--            <filename> sce-fw.bin </filename>	-->
+            <description> **Required.** Contains `camera-rtcpu-sce` firmware. </description>
+        </partition>
+        <partition name="sce-fw_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 1048576 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+<!--            <filename> sce-fw.bin </filename>	-->
+            <description> **Required.** Contains `camera-rtcpu-sce` firmware. </description>
+        </partition>
+        <partition name="bpmp-fw" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 1572864 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFFILE </filename>
+            <description> **Required.** Slot A; contains BPMP firmware. </description>
+        </partition>
+        <partition name="bpmp-fw_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 1572864 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFFILE </filename>
+            <description> **Required.** Slot B; contains BPMP firmware. </description>
+        </partition>
+        <partition name="bpmp-fw-dtb" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 1048576 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFDTB_FILE </filename>
+            <description> **Required.** Slot A; contains BPMP firmware device tree blob
+              (DTB). </description>
+        </partition>
+        <partition name="bpmp-fw-dtb_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 1048576 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFDTB_FILE </filename>
+            <description> **Required.** Slot B; contains BPMP firmware device tree blob
+              (DTB). </description>
+        </partition>
+	<partition name="CPUBL-CFG" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> CBOOTOPTION_FILE </filename>
+            <description> **Optional.** Contains boot device selection priority list. </description>
+        </partition>
+        <partition name="CPUBL-CFG_b" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> CBOOTOPTION_FILE </filename>
+            <description> **Optional.** Contains boot device selection priority list. </description>
+	</partition>
+	
+        <partition name="VER" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> VERFILE </filename>
+            <description> **Required.** Contains BSP version information. </description>
+        </partition>
+        <partition name="VER_b" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> VERFILE </filename>
+            <description> **Required.** Contains a redundant copy of BSP version information. </description>
+	</partition>
+	
+        <partition name="secondary_gpt" type="secondary_gpt">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 0xFFFFFFFFFFFFFFFF </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains secondary GPT of the `spi`
+              device. </description>
+        </partition>
+    </device>
+    <device type="sdmmc_user" instance="3" sector_size="512" num_sectors="33554432">
+        <partition name="master_boot_record" type="protective_master_boot_record">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 512 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains protective MBR. </description>
+        </partition>
+        <partition name="primary_gpt" type="primary_gpt">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 19968 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains primary GPT of the `sdmmc_user` device. All
+              partitions defined after this entry are configured in the kernel, and are
+              accessible by standard partition tools such as gdisk and parted. </description>
+        </partition>
+        <partition name="kernel" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 67108864 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FILENAME </filename>
+            <description> **Required.** Slot A; contains U-Boot, which loads and launches the kernel
+              from the rootfs at `/boot`. </description>
+        </partition>
+        <partition name="kernel_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 67108864 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FILENAME </filename>
+            <description> **Required.** Slot B; contains U-Boot, which loads and launches the kernel
+              from the rootfs at `/boot`. </description>
+        </partition>
+        <partition name="kernel-dtb" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 524288 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FILENAME </filename>
+            <description> **Required.** Slot A; contains kernel device tree blob. </description>
+        </partition>
+        <partition name="kernel-dtb_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 524288 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FILENAME </filename>
+            <description> **Required.** Slot B; contains kernel device tree blob. </description>
+        </partition>
+        <partition name="recovery-dtb" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 524288 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains recovery DTB image. </description>
+        </partition>
+        <partition name="kernel-bootctrl" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Slot A; contains boot control data. </description>
+        </partition>
+        <partition name="kernel-bootctrl_b" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Slot B; contains boot control data. </description>
+        </partition>
+        <partition name="PADDING" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 333426688 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Slot B; contains boot control data. </description>
+        </partition>
+        <partition name="resin-boot" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 125829120 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <filename> FILENAME </filename>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="resin-rootA" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 499122176 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <filename> FILENAME </filename>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="resin-rootB" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 499122176 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <filename> FILENAME </filename>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="resin-state" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 20971520 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <filename> FILENAME </filename>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="resin-data" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 212860928 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x808 </allocation_attribute>
+            <filename> FILENAME </filename>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="secondary_gpt" type="secondary_gpt">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 0xFFFFFFFFFFFFFFFF </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains secondary GPT of the `sdmmc_user`
+              device. </description>
+        </partition>
+    </device>
+</partition_layout>

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -61,7 +61,7 @@ const argv = yargs
 	.option('m', {
 		alias: 'machine',
 		description: 'Machine to flash',
-		choices: ['jetson-tx2', 'jetson-nano-emmc', 'jetson-nano-qspi-sd', 'jetson-xavier'],
+		choices: ['jetson-tx2', 'jetson-nano-emmc', 'jetson-nano-qspi-sd', 'jetson-xavier', 'jetson-xavier-nx-devkit-emmc'],
 		required: true,
 		type: 'string',
 	})

--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -41,7 +41,7 @@ module.exports = class ResinJetsonFlash {
 		this.dictionary = {
 			['jetson-tx2']: {
 				url:
-					'https://developer.nvidia.com/embedded/dlc/Jetson_Linux_R32.2.0-0',
+					'https://developer.nvidia.com/embedded/L4T/r32_Release_v4.2/t186ref_release_aarch64/Tegra186_Linux_R32.4.2_aarch64.tbz2',
 				partitions: {
 
 					kernel: { path: null },
@@ -60,7 +60,7 @@ module.exports = class ResinJetsonFlash {
 			},
 			['jetson-nano-emmc']: {
 				url:
-					'https://developer.nvidia.com/embedded/dlc/Jetson-210_Linux_R32.2.0-0',
+					'https://developer.nvidia.com/embedded/L4T/r32_Release_v4.2/t210ref_release_aarch64/Tegra210_Linux_R32.4.2_aarch64.tbz2',
 				partitions: {
 					LNX: { path: null },
 					DTB: { path: null },
@@ -76,7 +76,7 @@ module.exports = class ResinJetsonFlash {
 			},
 			['jetson-nano-qspi-sd']: {
 				url:
-					'https://developer.nvidia.com/embedded/dlc/Jetson-210_Linux_R32.2.0-0',
+					'https://developer.nvidia.com/embedded/L4T/r32_Release_v4.2/t210ref_release_aarch64/Tegra210_Linux_R32.4.2_aarch64.tbz2',
 				partitions: {
 					LNX: { path: null },
 					DTB: { path: null },
@@ -92,7 +92,7 @@ module.exports = class ResinJetsonFlash {
 			},
 			['jetson-xavier']: {
 				url:
-					'https://developer.nvidia.com/embedded/dlc/Jetson_Linux_R32.2.0-0',
+					'https://developer.nvidia.com/embedded/L4T/r32_Release_v4.2/t186ref_release_aarch64/Tegra186_Linux_R32.4.2_aarch64.tbz2',
 				partitions: {
 					'bootloader-dtb': { path: null },
 					'bootloader-dtb_b': { path: null },
@@ -110,6 +110,22 @@ module.exports = class ResinJetsonFlash {
 				},
 				medium: 'sdmmc_user',
 			},
+			['jetson-xavier-nx-devkit-emmc']: {
+                                url:
+                                        'https://developer.nvidia.com/embedded/L4T/r32_Release_v4.2/t186ref_release_aarch64/Tegra186_Linux_R32.4.2_aarch64.tbz2',
+                                partitions: {
+                                        kernel: { path: null },
+                                        kernel_b: { path: null },
+                                        'kernel-dtb': { path: null },
+                                        'kernel-dtb_b': { path: null },
+                                        'resin-boot': { path: null },
+                                        'resin-rootA': { path: null },
+                                        'resin-rootB': { path: null },
+                                        'resin-state': { path: null },
+                                        'resin-data': { path: null },
+                                },
+                                medium: 'sdmmc_user',
+                        },
 		};
 	}
 


### PR DESCRIPTION
Update flashing to L4T 32.4.2, add support for
flashing NX.

Change-type: minor
Signed-off-by: Alexandru Costache <alexandru@balena.io>