### PR TITLE
assets: don't extend last partition

### DIFF
--- a/assets/jetson-tx2-assets/resinOS-flash.xml
+++ b/assets/jetson-tx2-assets/resinOS-flash.xml
@@ -427,7 +427,7 @@
             <filesystem_type> basic </filesystem_type>
             <size> 1085276160 </size>
             <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x808  </allocation_attribute>
+            <allocation_attribute> 0x8  </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> FILENAME </filename>
         </partition>

--- a/assets/jetson-xavier-assets/resinOS-flash.xml
+++ b/assets/jetson-xavier-assets/resinOS-flash.xml
@@ -516,7 +516,7 @@
             <filesystem_type> basic </filesystem_type>
             <size> 212860928 </size>
             <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x808 </allocation_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename>FILENAME</filename>
         </partition>

--- a/assets/jetson-xavier-nx-devkit-assets/resinOS-flash.xml
+++ b/assets/jetson-xavier-nx-devkit-assets/resinOS-flash.xml
@@ -637,7 +637,7 @@
             <filesystem_type> basic </filesystem_type>
             <size> 212860928 </size>
             <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x808 </allocation_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
             <filename> FILENAME </filename>
             <percent_reserved> 0 </percent_reserved>
         </partition>

--- a/assets/jetson-xavier-nx-devkit-emmc-assets/resinOS-flash.xml
+++ b/assets/jetson-xavier-nx-devkit-emmc-assets/resinOS-flash.xml
@@ -640,7 +640,7 @@
             <filesystem_type> basic </filesystem_type>
             <size> 212860928 </size>
             <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x808 </allocation_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
             <filename> FILENAME </filename>
             <percent_reserved> 0 </percent_reserved>
         </partition>


### PR DESCRIPTION
The script for data partition
expansion expects that no partition
resize was done previously. If the
data partition is already expanded,
the filesystem will not be resized
anymore.

Let's leave the partition sizes
match the filesistem.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>