### PR TITLE
Allow flashing preloaded images

### DIFF
--- a/assets/jetson-nano-emmc-assets/resinOS-flash.xml
+++ b/assets/jetson-nano-emmc-assets/resinOS-flash.xml
@@ -238,7 +238,7 @@
         <partition  name="resin-data" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 212860928 </size>
+            <size> FILESIZE </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>

--- a/assets/jetson-nano-qspi-sd-assets/resinOS-flash.xml
+++ b/assets/jetson-nano-qspi-sd-assets/resinOS-flash.xml
@@ -238,7 +238,7 @@
         <partition id="25" name="resin-data" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 212860928 </size>
+            <size> FILESIZE </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>

--- a/assets/jetson-tx2-assets/resinOS-flash.xml
+++ b/assets/jetson-tx2-assets/resinOS-flash.xml
@@ -425,7 +425,7 @@
         <partition name="resin-data" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 1085276160 </size>
+            <size> FILESIZE </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8  </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>

--- a/assets/jetson-xavier-assets/resinOS-flash.xml
+++ b/assets/jetson-xavier-assets/resinOS-flash.xml
@@ -514,7 +514,7 @@
         <partition name="resin-data" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 212860928 </size>
+            <size> FILESIZE </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>

--- a/assets/jetson-xavier-nx-devkit-assets/resinOS-flash.xml
+++ b/assets/jetson-xavier-nx-devkit-assets/resinOS-flash.xml
@@ -635,7 +635,7 @@
         <partition name="resin-data" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 212860928 </size>
+            <size> FILESIZE </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <filename> FILENAME </filename>

--- a/assets/jetson-xavier-nx-devkit-emmc-assets/resinOS-flash.xml
+++ b/assets/jetson-xavier-nx-devkit-emmc-assets/resinOS-flash.xml
@@ -638,7 +638,7 @@
         <partition name="resin-data" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 212860928 </size>
+            <size> FILESIZE </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <filename> FILENAME </filename>

--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -216,7 +216,33 @@ module.exports = class ResinJetsonFlash {
 								});
 							});
 					});
+
+				/* Data partition size will differ according to the preloaded image size,
+				 * let's update the xml with the actual size in bytes. This is available
+				 * only for the data partition.
+				 */
+				value.elements.
+					filter(value => {
+						return (
+							value.name === 'partition' &&
+							Object.keys(options.partitions).includes(value.attributes.name) &&
+							value.attributes.name === 'resin-data'
+						);
+					})
+					.forEach(value => {
+						value.elements
+							.filter(element => {
+								return element.name === 'size';
+							})
+							.forEach(element => {
+								element.elements.forEach(size => {
+									size.text =
+										options.partitions['resin-data'].size;
+								});
+							});
+					});
 			});
+
 		return new Bluebird((resolve, reject) => {
 			const read = str(
 				convert.js2xml(result, {
@@ -268,6 +294,14 @@ module.exports = class ResinJetsonFlash {
 					resinImagePath,
 				);
 			}
+
+			const dataPartition = (await utils.getPartitionTableWithNames(
+				unwrappedImage,
+			)).partitions.find(part => {
+				return part.name === 'resin-data';
+			});
+			console.log(`Data partition size in bytes: ${dataPartition.size}`);
+			this.dictionary[this.deviceType].partitions['resin-data'].size = dataPartition.size;
 
 			await this.injectFilepathInFlashXML({
 				file: join(this.assetDir, 'resinOS-flash.xml'),


### PR DESCRIPTION
flash.xml is now updated with the
actual size of the data partition.
This is done only for this partition,
no other partitions sizes should be
modified.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>