### PR TITLE
Jetson Nano (SD & 2GB) L4T 32.5.1 flashing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ This tool is separate into two parts:
 Balena devices support
 ---------------------
 
-* NVidia Jetson NANO eMMC
-* NVidia Jetson Nano SD-CARD
-* NVidia Jetson TX2
-* NVidia Jetson TX2 (in Jetson Xavier NX Devkit)
-* NVidia Jetson Xavier AGX
-* NVidia Jetson Xavier NX Devkit eMMC
-* NVidia Jetson Xavier NX Devkit SD-CARD
+* Jetson NANO eMMC
+* Jetson Nano SD-CARD Devkit
+* Jetson Nano 2GB Devkit
+* Jetson TX2
+* Jetson TX2 NX (in Jetson Xavier NX Devkit)
+* Jetson Xavier AGX
+* Jetson Xavier NX Devkit eMMC
+* Jetson Xavier NX Devkit SD-CARD
 
 WARNINGS
 --------
@@ -40,14 +41,14 @@ Tool dependencies
 -----------------
 
 - [NodeJS](https://nodejs.org) (v10 or v12. Currently versions newer than v12 are incompatible, see issue #48)
-- This tool runs internally the Linux_for_Tegra package that Nvidia provides, so we assume you have all the dependencies for this tool installed.
+- This tool runs internally the Linux_for_Tegra package, so we assume you have all the dependencies for this tool installed.
 
 Getting Started
 ---------------
 
 NOTES:
  - Make sure that the Jetson board is pluged to your host via USB and is in recovery mode
- - Running the Nvidia flash tool requires sudo priviliges
+ - Running the Tegra flash tool requires sudo priviliges
  - This tool will produce all intermidiate steps in `/tmp/${pid_of_process}` and will require sudo priviliges to delete
  - If flashing Jetson TX2 with a BalenaOS image older than 2.47, please checkout tag 'v0.3.0'. BalenaOS 2.47 updated L4T version from 28.3 to 32.4.2.
  - Current BSP version used for flashing is L4T 32.5.1 for jetson-nano, jetson-nano-emmc and jetson-nano-2gb-devkit. Other devices are based on 32.4.4, please ensure the BalenaOS version you are flashing uses the same L4T, by consulting the changelog. v0.5.10 should be used for flashing devices on L4T 32.4.4.

--- a/assets/jetson-nano-2gb-devkit-assets/resinOS-flash.xml
+++ b/assets/jetson-nano-2gb-devkit-assets/resinOS-flash.xml
@@ -1,0 +1,390 @@
+<?xml version="1.0"?>
+
+<!-- Nvidia Tegra Partition Layout Version 1.0.0 -->
+
+<partition_layout version="01.00.0000">
+    <device type="spi" instance="0">
+       <partition name="BCT" type="boot_config_table">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains Boot Configuration Table (BCT). </description>
+        </partition>
+        <partition name="NXC" type="NVCTYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> NVCFILE </filename>
+            <description> **Required.** Contains TegraBoot binary. </description>
+        </partition>
+        <partition name="PT" type="partition_table">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> flash.xml.bin </filename>
+            <description> **Required.** Contains Partition Table. </description>
+        </partition>
+        <partition name="NXC_R" type="NVCTYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> NVCFILE </filename>
+            <description> **Required.** Contains a redundant copy of the TegraBoot
+              binary. </description>
+        </partition> 
+        <partition name="TXC" type="TBCTYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TBCFILE </filename>
+            <description> **Required.** Contains TegraBoot CPU-side binary. </description>
+        </partition>
+        <partition name="RP1" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 327680 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> DTBFILE </filename>
+            <description> **Required.** Contains Bootloader DTB binary. </description>
+        </partition>
+        <partition name="EBT" type="bootloader">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 589824 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> EBTFILE </filename>
+            <description> **Required.** Contains CBoot, the final boot stage CPU bootloader
+              binary that loads the binary in the kernel partition.. </description>
+        </partition>
+        <partition name="WX0" type="WB0TYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> WB0FILE </filename>
+            <description> **Required.** Contains warm boot binary. </description>
+        </partition>
+        <partition name="BXF" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFFILE </filename>
+            <description> **Required.** Contains SC7 entry firmware. </description>
+        </partition>
+        <partition name="BXF-DTB" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFDTB-FILE </filename>
+            <description> **Optional.** Reserved for future use by BPMP DTB binary;
+              can't remove. </description>
+        </partition>
+        <partition name="TXS" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 458752 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TOSFILE </filename>
+            <description> **Required.** Contains TOS binary. </description>
+   	 </partition>
+	 <!-- Image DTB is way larger, to account for future size increases, and cannot be
+	      stored in the qspi because the whole flash memory is 4MB. Apart from this, nvtboot
+	      expects these qspi partitions to be of standard sizes and at specific offsets. So there's
+	      not much that can be done other than store u-boot in here along the standard
+	      dtbs, and load any custom dtb from the rootfs (which we do anyway) -->
+        <partition name="DTB" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 327680 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> DTBFILE </filename>
+            <description> **Required.** Contains kernel DTB binary. </description>
+        </partition>
+        <partition name="LNX" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 917504 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FILENAME </filename>
+            <description> **Required.** Contains U-Boot, which loads and launches the kernel from
+              the rootfs at `/boot`. </description>
+        </partition>
+        <partition name="EXS" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> EKSFILE </filename>
+            <description> **Optional.** Contains the encrypted keys. </description>
+        </partition>
+        <partition name="RP4" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> rp4.blob </filename>
+            <description> **Required.** Contains XUSB firmware file, making XUSB
+              a true USB 3.0 compliant host controller. </description>
+        </partition>
+        <partition name="UBENV" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <start_location> 0x481000 </start_location>
+            <size> 512 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Reserved for U-Boot environment. </description>
+        </partition>
+       
+        <partition name="VER_b" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <start_location> 0x481800 </start_location>
+            <size> 512 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains a redundant copy of BSP version
+              information. </description>
+        </partition> 
+        <partition name="VER" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <start_location> 0x482000 </start_location>
+            <size> 512 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains BSP version information. </description>
+        </partition>
+    </device>
+    <device type="sdcard" instance="0">
+        <partition name="GP1" type="GP1">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 2097152 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="TBC" id="1" type="TBCTYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072</size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TBCFILE </filename>
+        </partition>
+        <partition name="RP1" id="2" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 917504 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved> 
+        </partition>
+        <partition name="EBT" id="3" type="bootloader">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 917504 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> EBTFILE </filename>
+        </partition>
+        <partition name="WB0" id="4" type="WB0TYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> WB0FILE </filename>
+        </partition>
+
+        <partition name="BPF" id="5" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFFILE </filename>
+    </partition>
+            <partition name="BXF-DTB" id="6" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 393216 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFDTB-FILE </filename>
+            <description> **Optional.** Reserved for future use by BPMP DTB binary; can't remove. </description>
+        </partition>
+        <partition name="FX" id="7" type="FBTYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FBFILE </filename>
+            <description> **Optional.** Reserved for fuse bypass; removeable. </description>
+        </partition>
+
+        <partition name="TOS" id="8" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 458752 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TOSFILE </filename>
+        </partition>
+        <partition name="EXS" id="9" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> EKSFILE </filename>
+        </partition>
+        <partition name="LNX" id="10" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 917504 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="DTB" id="11" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 917504  </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="RP4" id="12" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> rp4.blob </filename>
+        </partition>
+        <!-- Size is calculated so that it matches
+             the resin device specific space
+        -->
+        <partition name="BMP" id="13" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 45071360 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition id="14" name="resin-boot" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 83886080 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FILENAME </filename>
+        </partition>
+        <partition id="15" name="resin-rootA" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 499122176 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FILENAME </filename>
+        </partition>
+        <partition id="16" name="resin-rootB" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 499122176 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FILENAME </filename>
+        </partition>
+        <partition id="17" name="resin-state" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 20971520 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FILENAME </filename>
+        </partition>
+        <partition id="18" name="resin-data" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> FILESIZE </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FILENAME </filename>
+        </partition>
+        <partition  name="GPT" type="GPT">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 2097152 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+    </device>
+</partition_layout>

--- a/assets/jetson-nano-emmc-assets/resinOS-flash.xml
+++ b/assets/jetson-nano-emmc-assets/resinOS-flash.xml
@@ -140,7 +140,7 @@
         <partition name="TOS" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 458752 </size>
+            <size> 589824 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <partition_attribute> 0 </partition_attribute>
             <allocation_attribute> 8 </allocation_attribute>
@@ -193,7 +193,7 @@
         <partition name="BMP"  type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 46971904 </size>
+            <size> 46840832 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>

--- a/assets/jetson-nano-qspi-sd-assets/resinOS-flash.xml
+++ b/assets/jetson-nano-qspi-sd-assets/resinOS-flash.xml
@@ -4,16 +4,16 @@
 
 <partition_layout version="01.00.0000">
     <device type="spi" instance="0">
-        <partition name="BCT" id="2" type="boot_config_table">
+       <partition name="BCT" type="boot_config_table">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 262144 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains Boot Configuration Table (BCT). </description>
         </partition>
-
-        <partition name="NXC" id="3" type="NVCTYPE">
+        <partition name="NXC" type="NVCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -21,9 +21,9 @@
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> NVCFILE </filename>
+            <description> **Required.** Contains TegraBoot binary. </description>
         </partition>
-
-        <partition name="PT" id="4" type="partition_table">
+        <partition name="PT" type="partition_table">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -31,19 +31,115 @@
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> flash.xml.bin </filename>
+            <description> **Required.** Contains Partition Table. </description>
         </partition>
-
-        <!-- This is padding to ensure VER is at the end of flash -->
-        <partition name="PAD" id="5" type="data">
+        <partition name="NXC_R" type="NVCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 3604480 </size>
+            <size> 196608 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
+            <filename> NVCFILE </filename>
+            <description> **Required.** Contains a redundant copy of the TegraBoot
+              binary. </description>
         </partition>
-
-        <partition name="VER" id="6" type="data">
+        <partition name="TXC" type="TBCTYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TBCFILE </filename>
+            <description> **Required.** Contains TegraBoot CPU-side binary. </description>
+        </partition>
+        <partition name="RP1" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 458752 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> DTBFILE </filename>
+            <description> **Required.** Contains Bootloader DTB binary. </description>
+        </partition>
+        <partition name="EBT" type="bootloader">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 589824 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> EBTFILE </filename>
+            <description> **Required.** Contains CBoot, the final boot stage CPU bootloader
+              binary that loads the binary in the kernel partition.. </description>
+        </partition>
+        <partition name="WX0" type="WB0TYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> WB0FILE </filename>
+            <description> **Required.** Contains warm boot binary. </description>
+        </partition>
+        <partition name="BXF" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 196608 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFFILE </filename>
+            <description> **Required.** Contains SC7 entry firmware. </description>
+        </partition>
+        <partition name="BXF-DTB" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFDTB-FILE </filename>
+            <description> **Optional.** Reserved for future use by BPMP DTB binary;
+              can't remove. </description>
+        </partition>
+        <partition name="TXS" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 458752 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TOSFILE </filename>
+            <description> **Required.** Contains TOS binary. </description>
+        </partition>
+        <partition name="DTB" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 458752 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FILENAME </filename>
+            <description> **Required.** Contains kernel DTB binary. </description>
+        </partition>
+        <partition name="LNX" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 786432 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FILENAME </filename>
+            <description> **Required.** Contains U-Boot, which loads and launches the kernel from
+              the rootfs at `/boot`. </description>
+        </partition>
+        <partition name="EXS" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -51,12 +147,56 @@
             <partition_attribute> 0 </partition_attribute>
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
-            <filename> VERFILE </filename>
+            <filename> EKSFILE </filename>
+            <description> **Optional.** Contains the encrypted keys. </description>
         </partition>
-
+        <partition name="RP4" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> rp4.blob </filename>
+            <description> **Required.** Contains XUSB firmware file, making XUSB
+              a true USB 3.0 compliant host controller. </description>
+        </partition>
+        <partition name="UBENV" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <start_location> 0x420800 </start_location>
+            <size> 512 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Reserved for U-Boot environment. </description>
+        </partition>
+        <partition name="VER_b" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <start_location> 0x421800 </start_location>
+            <size> 512 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains a redundant copy of BSP version
+              information. </description>
+        </partition>
+        <partition name="VER" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <start_location> 0x422000 </start_location>
+            <size> 512 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <partition_attribute> 0 </partition_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Contains BSP version information. </description>
+        </partition>
     </device>
     <device type="sdcard" instance="0">
-        <partition name="GP1" id="7" type="GP1">
+        <partition name="GP1" type="GP1">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2097152 </size>
@@ -64,7 +204,7 @@
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
         </partition>
-        <partition name="TBC" id="8" type="TBCTYPE">
+        <partition name="TBC" id="1" type="TBCTYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072</size>
@@ -73,18 +213,16 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> TBCFILE </filename>
         </partition>
-
-        <partition name="RP1" id="9" type="data">
+        <partition name="RP1" id="2" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 458752 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
-            <filename> DTBFILE </filename>
+ 
         </partition>
-
-        <partition name="EBT" id="11" type="bootloader">
+        <partition name="EBT" id="3" type="bootloader">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 589824 </size>
@@ -93,8 +231,7 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> EBTFILE </filename>
         </partition>
-
-        <partition name="WB0" id="12" type="WB0TYPE">
+        <partition name="WB0" id="4" type="WB0TYPE">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -104,7 +241,7 @@
             <filename> WB0FILE </filename>
         </partition>
 
-        <partition name="BPF" id="13" type="data">
+        <partition name="BPF" id="5" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -114,18 +251,17 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> BPFFILE </filename>
         </partition>
-
-        <partition name="TOS" id="14" type="data">
+        <partition name="TOS" id="6" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 458752 </size>
+            <size> 589824 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <partition_attribute> 0 </partition_attribute>
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> TOSFILE </filename>
         </partition>
-        <partition name="EXS" id="15" type="data">
+        <partition name="EXS" id="7" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 65536 </size>
@@ -135,26 +271,23 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> EKSFILE </filename>
         </partition>
-        <partition name="LNX" id="16" type="data">
+        <partition name="LNX" id="8" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 786432 </size>
+            <size> 655360 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
-            <filename> FILENAME </filename>
         </partition>
-        <partition name="DTB" id="17" type="data">
+        <partition name="DTB" id="9" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 458752 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
-            <filename> FILENAME </filename>
         </partition>
-
-        <partition name="RP4" id="18" type="data">
+        <partition name="RP4" id="10" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 131072 </size>
@@ -166,16 +299,15 @@
         <!-- Size is calculated so that it matches
              the resin device specific space
         -->
-        <partition name="BMP" id="19" type="data">
+        <partition name="BMP" id="11" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 46971904 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
-            <filename> bmp.blob </filename>
         </partition>
-        <partition id="20" name="resin-boot" type="data">
+        <partition id="12" name="resin-boot" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 83886080 </size>
@@ -184,7 +316,7 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> FILENAME </filename>
         </partition>
-        <partition id="21" name="resin-rootA" type="data">
+        <partition id="13" name="resin-rootA" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 499122176 </size>
@@ -193,7 +325,7 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> FILENAME </filename>
         </partition>
-        <partition id="22" name="resin-rootB" type="data">
+        <partition id="14" name="resin-rootB" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 499122176 </size>
@@ -202,7 +334,7 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> FILENAME </filename>
         </partition>
-        <partition id="23" name="resin-state" type="data">
+        <partition id="15" name="resin-state" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 20971520 </size>
@@ -211,7 +343,7 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> FILENAME </filename>
         </partition>
-        <partition id="24" name="resin-data" type="data">
+        <partition id="16" name="resin-data" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> FILESIZE </size>
@@ -220,7 +352,7 @@
             <percent_reserved> 0 </percent_reserved>
             <filename> FILENAME </filename>
         </partition>
-        <partition  name="GPT" id="25" type="GPT">
+        <partition  name="GPT" type="GPT">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 2097152 </size>

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -61,7 +61,7 @@ const argv = yargs
 	.option('m', {
 		alias: 'machine',
 		description: 'Machine to flash',
-		choices: ['jetson-tx2', 'jetson-tx2-4GB', 'jetson-xavier-nx-devkit-tx2-nx', 'jetson-nano-emmc', 'jetson-nano-qspi-sd', 'jetson-xavier', 'jetson-xavier-nx-devkit-emmc', "jetson-xavier-nx-devkit"],
+		choices: ['jetson-tx2', 'jetson-tx2-4GB', 'jetson-xavier-nx-devkit-tx2-nx', 'jetson-nano-emmc', 'jetson-nano-qspi-sd', 'jetson-nano-2gb-devkit', 'jetson-xavier', 'jetson-xavier-nx-devkit-emmc', "jetson-xavier-nx-devkit"],
 		required: true,
 		type: 'string',
 	})

--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -127,7 +127,7 @@ module.exports = class ResinJetsonFlash {
 					'resin-state': { path: null },
 					'resin-data': { path: null },
 				},
-				medium: 'sdcard',
+				medium: ['sdcard', 'spi']
 			},
 			['jetson-xavier']: {
 				url:
@@ -235,7 +235,8 @@ module.exports = class ResinJetsonFlash {
 				return value.name === 'partition_layout';
 			})
 			.elements.filter(value => {
-				return (
+				return ( this.deviceType === 'jetson-nano-qspi-sd' ?
+					value.attributes.type === this.dictionary[this.deviceType].medium[0] || value.attributes.type === this.dictionary[this.deviceType].medium[1] :
 					value.attributes.type === this.dictionary[this.deviceType].medium
 				);
 			})

--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -113,6 +113,20 @@ module.exports = class ResinJetsonFlash {
 				},
 				medium: 'sdmmc',
 			},
+			['jetson-nano-2gb-devkit']: {
+                                url:
+                                        'https://developer.nvidia.com/embedded/l4t/r32_release_v5.1/r32_release_v5.1/t210/jetson-210_linux_r32.5.1_aarch64.tbz2',
+                                partitions: {
+                                        LNX: { path: null },
+                                        BMP: { path: null },
+                                        'resin-boot': { path: null },
+                                        'resin-rootA': { path: null },
+                                        'resin-rootB': { path: null },
+                                        'resin-state': { path: null },
+                                        'resin-data': { path: null },
+                                },
+                                medium: ['sdcard', 'spi']
+                        },
 			['jetson-nano-qspi-sd']: {
 				url:
 					'https://developer.nvidia.com/embedded/l4t/r32_release_v5.1/r32_release_v5.1/t210/jetson-210_linux_r32.5.1_aarch64.tbz2',
@@ -235,7 +249,7 @@ module.exports = class ResinJetsonFlash {
 				return value.name === 'partition_layout';
 			})
 			.elements.filter(value => {
-				return ( this.deviceType === 'jetson-nano-qspi-sd' ?
+				return ( this.deviceType === 'jetson-nano-qspi-sd' || this.deviceType === 'jetson-nano-2gb-devkit' ?
 					value.attributes.type === this.dictionary[this.deviceType].medium[0] || value.attributes.type === this.dictionary[this.deviceType].medium[1] :
 					value.attributes.type === this.dictionary[this.deviceType].medium
 				);


### PR DESCRIPTION
- Fix flashing L4T 32.5.1 cloud images on Nano SD-CARD Devkit
- Add support for flashing L4T 32.5.1 cloud images on Nano 2GB Devkit
No changes needed for flashing Nano eMMC modules.

These are necessary since since L4T 32.5.1 moved tegra partitions from the sd-card to the spi flash, and for the case where the Nano's qspi flash has been flashed by Ubuntu images.

```
Tests run:

2.82.11 Nano 2GB IMG:
14      50331648B    134217727B   83886080B   fat16        resin-boot   boot, esp
15      134217728B   633339903B   499122176B  ext4         resin-rootA
16      633339904B   1132462079B  499122176B  ext4         resin-rootB
17      1132462080B  1153433599B  20971520B   ext4         resin-state
18      1153433600B  1366294527B  212860928B  ext4         resin-data


2.82.11 Nano 2GB image flashed:
14      50331648B    134217727B    83886080B     fat16        resin-boot   msftdata
15      134217728B   633339903B    499122176B    ext4         resin-rootA  msftdata
16      633339904B   1132462079B   499122176B    ext4         resin-rootB  msftdata
17      1132462080B  1153433599B   20971520B     ext4         resin-state  msftdata
18      1153433600B  31914967039B  30761533440B  ext4         resin-data   msftdata

HUP: OK

====================================================================================

2.82.11 Nano SD-CARD Devkit IMG:

12      50331648B    134217727B   83886080B   fat16        resin-boot   boot, esp
13      134217728B   633339903B   499122176B  ext4         resin-rootA
14      633339904B   1132462079B  499122176B  ext4         resin-rootB
15      1132462080B  1153433599B  20971520B   ext4         resin-state
16      1153433600B  1366294527B  212860928B  ext4         resin-data

2.82.11 Nano SD-CARD Devkit image flashed:
12      50331648B    134217727B    83886080B     fat16        resin-boot   msftdata
13      134217728B   633339903B    499122176B    ext4         resin-rootA  msftdata
14      633339904B   1132462079B   499122176B    ext4         resin-rootB  msftdata
15      1132462080B  1153433599B   20971520B     ext4         resin-state  msftdata
16      1153433600B  31914967039B  30761533440B  ext4         resin-data   msftdata

HUP: OK

====================================================================================

2.82.11 Nano eMMC (in Devkit) IMG:

12      50331648B    134217727B   83886080B   fat16        resin-boot   boot, esp
13      134217728B   633339903B   499122176B  ext4         resin-rootA
14      633339904B   1132462079B  499122176B  ext4         resin-rootB
15      1132462080B  1153433599B  20971520B   ext4         resin-state
16      1153433600B  1366294527B  212860928B  ext4         resin-data

2.82.11 Nano eMMC (in Devkit) image flashed:

12      50331648B    134217727B    83886080B     fat16        resin-boot   msftdata
13      134217728B   633339903B    499122176B    ext4         resin-rootA  msftdata
14      633339904B   1132462079B   499122176B    ext4         resin-rootB  msftdata
15      1132462080B  1153433599B   20971520B     ext4         resin-state  msftdata
16      1153433600B  15757983743B  14604550144B  ext4         resin-data   msftdata

HUP: OK
```