### PR TITLE
Xavier AGX: Use bpmp-fw-dtb from the image instead of the default one

### DIFF
--- a/assets/jetson-xavier-assets/resinOS-flash.xml
+++ b/assets/jetson-xavier-assets/resinOS-flash.xml
@@ -289,7 +289,7 @@
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
-            <filename> BPFDTB_FILE </filename>
+            <filename> FILENAME </filename>
         </partition>
         <partition name="bpmp-fw-dtb_b" type="data" oem_sign="true">
             <allocation_policy> sequential </allocation_policy>
@@ -298,7 +298,7 @@
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
-            <filename> BPFDTB_FILE </filename>
+            <filename> FILENAME </filename>
         </partition>
         <partition name="xusb-fw" type="data">
             <allocation_policy> sequential </allocation_policy>

--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -155,6 +155,8 @@ module.exports = class ResinJetsonFlash {
 					'kernel-dtb_b': { path: null },
 					BMP: { path: null },
 					BMP_b: { path: null },
+					'bpmp-fw-dtb': { path: null },
+					'bpmp-fw-dtb_b': { path: null },
 					'resin-boot': { path: null },
 					'resin-rootA': { path: null },
 					'resin-rootB': { path: null },


### PR DESCRIPTION
The image might contain a custom bpmp-fw-dtb
that changes parent clocks in can related nodes,
let's use this one instead of the default dtb
provided by the BSP.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>