### PR TITLE
jetson-tx2: Allow specifying odmdata value

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -46,9 +46,12 @@ const run = async options => {
 
 	await utils.outputRegister(outputPath, options.persistent);
 
+	const odmdata = options.odmdata ? options.odmdata : 'default';
+
 	const Flasher = new ResinJetsonFlash(
 		options.machine,
 		options.file,
+		odmdata,
 		`${__dirname}/../assets/${options.machine}-assets`,
 		outputPath,
 	);
@@ -68,7 +71,13 @@ const argv = yargs
 	.alias('f', 'file')
 	.nargs('f', 1)
 	.describe('f', 'BalenaOS image to use')
-	.demandOption(['f'])
+	.option('d', {
+		alias: 'odmdata',
+		description: 'ODMDATA value, currently available for Jetson TX2 only',
+		choices: ['0x1090000', '0x90000', '0x6090000', '0x7090000', '0x2090000', '0x3090000'],
+		required: false,
+		type: 'string',
+	})
 	.alias('o', 'output')
 	.nargs('o', 1)
 	.describe('o', 'Output directory')

--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -34,9 +34,10 @@ const {
 const utils = require('./utils.js');
 
 module.exports = class ResinJetsonFlash {
-	constructor(deviceType, image, assetDir, output) {
+	constructor(deviceType, image, odmdata, assetDir, output) {
 		this.deviceType = deviceType;
 		this.image = image;
+		this.odmdata = odmdata;
 		this.assetDir = assetDir;
 		this.output = output;
 		this.dictionary = {
@@ -215,6 +216,27 @@ module.exports = class ResinJetsonFlash {
 			fs.closeSync(fs.openSync(workPath + '/bootloader/recovery.img', 'w'));
 			fs.writeFileSync(workPath + '/tools/ota_tools/version_upgrade/recovery_copy_binlist.txt', '');
 			fs.writeFileSync(workPath + '/tools/ota_tools/version_upgrade/ota_make_recovery_img_dtb.sh', '');
+
+			if ("default" != this.odmdata.toString()) {
+				if ("jetson-tx2" == this.deviceType.toString()) {
+					/* flash.sh from the BSP has a bug which causes the -o argument
+					 * to be ignored. Let's edit the configuration file to overcome this
+					 */
+					const odmfile = join(workPath, '/p2771-0000.conf.common');
+					console.log('Using ODMDATA value: ' + this.odmdata.toString());
+					try {
+						var data = fs.readFileSync(odmfile, 'utf8');
+						// Default ODMDATA configuration option in the BSP archive is #2 - 0x1090000
+						var result = data.replace(/ODMDATA=0x1090000/g, 'ODMDATA=' +  this.odmdata.toString());
+						console.log("Replaced ODMDATA in " + odmfile);
+						fs.writeFileSync(odmfile, result, 'utf8');
+					} catch (err) {
+						console.error(err);
+					}
+				}
+			} else {
+				console.log("ODMDATA not specified, using default value set by BSP archive")
+			}
 
 			const child = spawn(
 				'sudo',


### PR DESCRIPTION
The BSP's flash.sh specifies the -o option for setting odmdata,
however, the value provided is ignored.

We therefore edit the common conf
file for the TX2 and replace the
default ODMDATA value in it with
the one provided to jetson-flash
via the -d cmdline argument.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>

Addresses: https://github.com/balena-os/jetson-flash/issues/58