### PR TITLE
Update list of devices using L4T 32.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ NOTES:
  - Running the Tegra flash tool requires sudo priviliges
  - This tool will produce all intermidiate steps in `/tmp/${pid_of_process}` and will require sudo priviliges to delete
  - If flashing Jetson TX2 with a BalenaOS image older than 2.47, please checkout tag 'v0.3.0'. BalenaOS 2.47 updated L4T version from 28.3 to 32.4.2.
- - Current BSP version used for flashing is L4T 32.6.1 for jetson-nano, jetson-nano-emmc and jetson-xavier-nx-devkit-tx2-nx - for the TX2 NX. Other devices are based on 32.5.1, please ensure the BalenaOS version you are flashing uses the same L4T, by consulting the changelog. v0.5.10 should be used for flashing devices on L4T 32.4.4.
-   available in the [BalenaOS Jetson](https://github.com/balena-os/balena-jetson/commits/master) repository.
+ - Current BSP version used for flashing is L4T 32.6.1. Please ensure the BalenaOS version you are flashing uses the same L4T, by consulting the changelog available in the [BalenaOS Jetson repository](https://github.com/balena-os/balena-jetson/commits/master). Jetson Flash v0.5.10 should be used for flashing devices on L4T 32.4.4.
 
 Clone this repository
 ```sh

--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -60,25 +60,6 @@ module.exports = class ResinJetsonFlash {
 				},
 				medium: 'sdmmc_user',
 			},
-			['jetson-tx2-4GB']: {
-				url:
-					'https://developer.nvidia.com/embedded/L4T/r32_Release_v4.4/r32_Release_v4.4-GMC3/T186/Tegra186_Linux_R32.4.4_aarch64.tbz2',
-				partitions: {
-
-					kernel: { path: null },
-					kernel_b: { path: null },
-					'bootloader-dtb': { path: null },
-                                        'bootloader-dtb_b': { path: null },
-					'kernel-dtb': { path: null },
-					'kernel-dtb_b': { path: null },
-					'resin-boot': { path: null },
-					'resin-rootA': { path: null },
-					'resin-rootB': { path: null },
-					'resin-state': { path: null },
-					'resin-data': { path: null },
-				},
-				medium: 'sdmmc_user',
-			},
 			['jetson-xavier-nx-devkit-tx2-nx']: {
                                 url:
                                         'https://developer.nvidia.com/embedded/l4t/r32_release_v6.1/t186/jetson_linux_r32.6.1_aarch64.tbz2',


### PR DESCRIPTION
Adding `jetson-xavier-nx-devkit-emmc` to the list of devices that require BSP L4T 32.6.1 as a identified in this ticket https://jel.ly.fish/support-thread-balenaos-xavier-nx-emmc-47bc640