### PR TITLE
assets: Set AGX Orin device specific size and partition sizes

### DIFF
--- a/assets/jetson-agx-orin-devkit-assets/resinOS-flash.xml
+++ b/assets/jetson-agx-orin-devkit-assets/resinOS-flash.xml
@@ -624,7 +624,7 @@
         <partition name="esp" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 67108864 </size>
+            <size> 70496256 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 0x8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
@@ -643,7 +643,7 @@
         <partition name="resin-rootA" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 750780416 </size>
+            <size> 1027604480 </size>
             <file_system_attribute> 0 </file_system_attribute>
 	    <allocation_attribute> 0x8 </allocation_attribute>
 	    <filename> FILENAME </filename>
@@ -652,7 +652,7 @@
         <partition name="resin-rootB" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 750780416 </size>
+            <size> 1027604480 </size>
             <file_system_attribute> 0 </file_system_attribute>
 	    <allocation_attribute> 0x8 </allocation_attribute>
 	    <filename> FILENAME </filename>


### PR DESCRIPTION
... to match the cloud production release.

The staging device specific offset and root partition size are set for the pre-production, (staging) release.

In this commit we set the production device specific size, where the nvidia partitions are located, as well as the balena root file sysitem partition size to match the ones in a cloud image.

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>