### PR TITLE
lib: Update Jetson TX2 to L4T 32.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Balena devices support
 * Jetson Nano eMMC - L4T 32.7.2
 * Jetson Nano SD-CARD Devkit - L4T 32.7.2
 * Jetson Nano 2GB Devkit - L4T 32.7.1
-* Jetson TX2 - L4T 32.7.1
+* Jetson TX2 - L4T 32.7.2
 * Jetson TX2 NX (in Jetson Xavier NX Devkit) - L4T 32.7.2
 * Jetson Xavier AGX - L4T 32.7.1
 * Jetson Xavier NX Devkit eMMC - L4T 32.7.1

--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -43,7 +43,7 @@ module.exports = class ResinJetsonFlash {
 		this.dictionary = {
 			['jetson-tx2']: {
 				url:
-					'https://developer.nvidia.com/embedded/l4t/r32_release_v7.1/t186/jetson_linux_r32.7.1_aarch64.tbz2',
+					'https://developer.nvidia.com/embedded/l4t/r32_release_v7.2/t186/jetson_linux_r32.7.2_aarch64.tbz2',
 				partitions: {
 
 					kernel: { path: null },


### PR DESCRIPTION
This corresponds to balenaOS v2.106.7
and newer

Change-type: patch
Signed-off-by: Alexandru Costache <alexandru@balena.io>