### PR TITLE
add simple test for artifact generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.40",
   "description": "This tool allows users to flash BalenaOS on specific Jetson devices using Nvidia flashing tools.",
   "scripts": {
-    "test": "bin/cmd.js --version",
+    "test": "tap --timeout=0 --no-coverage",
     "start": "bin/cmd.js"
   },
   "repository": {
@@ -23,6 +23,7 @@
   "homepage": "https://github.com/balena-os/jetson-flash#readme",
   "dependencies": {
     "balena-image-fs": "^7.2.0",
+    "balena-sdk": "^16.38.0",
     "bluebird": "^3.7.2",
     "ext2fs": "^3.0.5",
     "file-disk": "^7.0.1",
@@ -48,5 +49,8 @@
   },
   "engines": {
     "node": ">=16"
+  },
+  "devDependencies": {
+    "tap": "^16.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.40",
   "description": "This tool allows users to flash BalenaOS on specific Jetson devices using Nvidia flashing tools.",
   "scripts": {
-    "test": "tap --timeout=0 --no-coverage",
+    "test": "tap --timeout=0 --no-coverage --after=tests/cleanup.js",
     "start": "bin/cmd.js"
   },
   "repository": {

--- a/tests/cleanup.js
+++ b/tests/cleanup.js
@@ -1,0 +1,5 @@
+const fs = require('fs')
+
+console.log('cleaning up images')
+fs.unlinkSync('jetson-tx2.img');
+fs.rmSync('jetson-flash-artifacts', { recursive: true, force: true });

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,38 @@
+const tap = require('tap')
+const fs = require('fs')
+const ResinJetsonFlash = require('../lib/resin-jetson-flash.js');
+
+
+const { getSdk } = require('balena-sdk');
+
+const IMAGE_PATH = 'jetson-tx2.img'
+
+const balena = getSdk({
+    apiUrl: "https://api.balena-cloud.com/",
+});
+
+tap.test('Test jetson-flash artifact preperation', async t => {
+    // download tx2 image with sdk 
+    await new Promise(async (resolve, reject) => {
+        t.comment('Downloading image...')
+        balena.models.os.download('jetson-tx2').then(function(stream) {
+            stream.pipe(fs.createWriteStream(IMAGE_PATH));
+            stream.on("finish", () => {
+                resolve();
+            })
+        });
+    })
+
+    const Flasher = new ResinJetsonFlash(
+		'jetson-tx2',
+		IMAGE_PATH,
+		'',
+		`${__dirname}/../assets/jetson-tx2-assets`,
+		'./jetson-flash-artifacts',
+	);
+
+    await t.resolves(
+        Flasher.generateArtifacts(),
+        'Should generate artifacts without errors'
+    )
+})


### PR DESCRIPTION
Following the update to node 16+ I thought it would be sensible to add a simple "e2e" test to check that the majority of the actions performed by the node code works correctly, mainly the artifact generation, and unwrapping the os image from the flasher image

Change-type: patch

