### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,25 @@
 FROM balenalib/amd64-ubuntu:focal-run-20221210
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN \
-    apt update && apt install -y python2 python3 python3-pip usbutils curl && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python2 1
-
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
-
-RUN pip3 install pyyaml
-
 WORKDIR /usr/src/app/jetson-flash
+COPY .  /usr/src/app/jetson-flash
 
-RUN \
-    apt-get update && apt-get install -y lbzip2 git wget unzip e2fsprogs dosfstools libxml2-utils nodejs
-    
-COPY . /usr/src/app/jetson-flash
-
-RUN npm install
+ARG DEBIAN_FRONTEND=noninteractive
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -       && \
+    apt-get -yqq install python2                                               \
+                         python3                                               \
+                         python3-pip                                           \
+                         usbutils                                              \
+                         lbzip2                                                \
+                         git                                                   \
+                         wget                                                  \
+                         unzip                                                 \
+                         e2fsprogs                                             \
+                         dosfstools                                            \
+                         libxml2-utils                                         \
+                         nodejs                                                \
+                         xxd                                                && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python2 1 && \
+    pip3 install pyyaml                                                     && \
+    npm install
 
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
* Set DEBIAN_FRONTEND variable during build time only
* Add xxd package (required by L4T)
* Remove curl from package list (already present in base image)
* nodejs installer run apt-get update automatically, no need to do it again