### PR TITLE
assets: enable pre expansion of resin-data partition on Nano DTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # jetson-flash
 
+IMPORTANT NOTE: As of Sep 19 2023 the Jetson Nano and Jetson Xavier L4T 32.7.2 and 32.7.1 BSP archive links are broken on Nvidia's website.
+Thus, provisioning L4T 32.7.2 or older on devices is currently not possible. We are working on releasing L4T 32.7.3 balenaOS images for the
+affected devices.
+
 This tool allows users to flash balenaOS on supported Jetson devices:
 
 |Device | balena machine name | L4T version |

--- a/assets/jetson-nano-emmc-assets/resinOS-flash.xml
+++ b/assets/jetson-nano-emmc-assets/resinOS-flash.xml
@@ -240,7 +240,7 @@
             <filesystem_type> basic </filesystem_type>
             <size> FILESIZE </size>
             <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x8 </allocation_attribute>
+            <allocation_attribute> 0x808 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> FILENAME </filename>
         </partition>

--- a/assets/jetson-nano-qspi-sd-assets/resinOS-flash.xml
+++ b/assets/jetson-nano-qspi-sd-assets/resinOS-flash.xml
@@ -348,7 +348,7 @@
             <filesystem_type> basic </filesystem_type>
             <size> FILESIZE </size>
             <file_system_attribute> 0 </file_system_attribute>
-            <allocation_attribute> 0x8 </allocation_attribute>
+            <allocation_attribute> 0x808 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
             <filename> FILENAME </filename>
         </partition>


### PR DESCRIPTION
.. by the BSP flasing tools. Expansion is done in in the initramfs if necessary but it won't hurt expanding the data partition using the BSP flashing tools if they support this, and only expand the root filesystem from iniramfs scripts.

Also, add a note about broken BSP links for L4T 32.7.2

Change-type: patch