### PR TITLE
lib/resin-jetson-flash: Update Xavier NX eMMC to L4T 32.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This tool allows users to flash balenaOS on supported Jetson devices:
 |Jetson TX2 | jetson-tx2 | L4T 32.7.3 |
 |Jetson TX2 NX (in Jetson Xavier NX Devkit) | jetson-tx2-nx-devkit | L4T 32.7.3 |
 |Jetson AGX Xavier | jetson-xavier | L4T 32.7.3 |
-|Jetson Xavier NX Devkit eMMC | jetson-xavier-nx-devkit-emmc | L4T 32.7.2 |
+|Jetson Xavier NX Devkit eMMC | jetson-xavier-nx-devkit-emmc | L4T 32.7.3 |
 |Jetson Xavier NX Devkit SD-CARD | jetson-xavier-nx-devkit | L4T 32.7.3 |
 |Jetson AGX Orin Devkit | jetson-agx-orin-devkit | L4T 35.3.1 |
 |Jetson Orin Nano 8GB (SD) Devkit NVME | jetson-orin-nano-devkit-nvme | L4T 35.3.1 |

--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -161,7 +161,7 @@ module.exports = class ResinJetsonFlash {
                         },
 			['jetson-xavier-nx-devkit-emmc']: {
                                 url:
-                                        'https://developer.nvidia.com/embedded/l4t/r32_release_v7.2/t186/jetson_linux_r32.7.2_aarch64.tbz2',
+                                        'https://developer.nvidia.com/downloads/remksjetpack-463r32releasev73t186jetsonlinur3273aarch64tbz2',
                                 partitions: {
                                         kernel: { path: null },
                                         kernel_b: { path: null },


### PR DESCRIPTION
Change-type: patch