### PR TITLE
build: Replace URLs with prefetched BSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ For **Docker**, issue the following commands in the folder that has the Dockerfi
 You can then enter the container using:
 
 ```sh
-docker container run --rm -it --privileged -v /dev/bus/usb:/dev/bus/usb -v ~/images:/data/images jf-image /bin/bash
+docker container run --rm -it --privileged -v /dev/bus/usb:/dev/bus/usb -v ~/images:/data/images jf-image /usr/src/app/jetson-flash/run_http_server.sh
 ```
 
 Alternatively, run the provided docker-compose file with `docker-compose up` and ssh into the container with `docker exec -it <container name> /bin/bash` 

--- a/build.sh
+++ b/build.sh
@@ -70,6 +70,7 @@ case "${DEVICE_TYPE}" in
             echo $"Using default L4T 32.7.3 BSP ${JETSON_FLASH_BSP_URL}"
 esac
 
+sed -i "s|${JETSON_FLASH_BSP_URL}|http:\/\/127.0.0.1/L4T_BSP_${DEVICE_TYPE}.tbz2|g" lib/resin-jetson-flash.js
 
 # Build Dockerfile
-docker build --build-arg bsp_url="${JETSON_FLASH_BSP_URL}" --build-arg device_type="${DEVICE_TYPE}" -t jetson-flash-image .
+docker build --build-arg bsp_url="${JETSON_FLASH_BSP_URL}" --build-arg device_type="${DEVICE_TYPE}" -t jf-image .


### PR DESCRIPTION
Since the BSP archive can be pre-fetched and served locally by the python http server, let's also replace the URLs inside jetson-flash for that particular
device-type.

Change-type: patch