### PR TITLE
add cache flag to node app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,6 @@ COPY .  /usr/src/app/jetson-flash
 
 RUN npm install
 
-RUN wget "$bsp_url" -O "/tmp/L4T_BSP_$device_type.tbz2"  && echo "BSP archive for $device_type saved in /tmp/L4T_BSP_$device_type.tbz2, can be downloaded from http://127.0.0.1/L4T_BSP_$device_type.tbz2"
+RUN wget "$bsp_url" -O "/tmp/Linux_for_Tegra.tbz2"  && tar -xvf "/tmp/Linux_for_Tegra.tbz2" -C "/tmp/" && rm /tmp/Linux_for_Tegra.tbz2
 
 CMD ["./run_http_server.sh"]

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -60,7 +60,7 @@ const run = async options => {
 	}
 
 	const outputPath = options.persistent
-		? path.join(options.output, 'jetson-flash-artifacts')
+		? path.join(options.output, 'jetson-flash-artifacts') //  '/tmp/jetson-flash-artifacts'
 		: path.join(options.output, process.pid.toString());
 
 	await utils.outputRegister(outputPath, options.persistent);
@@ -73,6 +73,7 @@ const run = async options => {
 		odmdata,
 		`${__dirname}/../assets/${options.machine}-assets`,
 		outputPath,
+		options.cache
 	);
 
 	await Flasher.run();
@@ -112,6 +113,9 @@ const argv = yargs
 	.describe('p', 'Persist work')
 	.implies('p', 'o')
 	.example('$0 -f balena.img -p -o ./workdir --acceptLicense yes', '')
+	.alias('c', 'cache')
+	.boolean('c')
+	.describe('c', 'use cached bsp from dockerfile')
 	.help('h')
 	.alias('h', 'help')
 	.epilog('Copyright 2020').argv;

--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -34,12 +34,13 @@ const {
 const utils = require('./utils.js');
 const path = require('path');
 module.exports = class ResinJetsonFlash {
-	constructor(deviceType, image, odmdata, assetDir, output) {
+	constructor(deviceType, image, odmdata, assetDir, output, cache) {
 		this.deviceType = deviceType;
 		this.image = image;
 		this.odmdata = odmdata;
 		this.assetDir = assetDir;
 		this.output = output;
+		this.cache = cache;
 		this.dictionary = {
 			['jetson-tx2']: {
 				url:
@@ -376,7 +377,7 @@ module.exports = class ResinJetsonFlash {
 
 	async generateArtifacts() {
 		const nvidiaToolPath = join(this.output, 'Linux_for_Tegra');
-		if (!(await utils.checkConsistency(nvidiaToolPath))) {
+		if ((!(await utils.checkConsistency(nvidiaToolPath)) && !this.cache)) {
 			await utils.decompressTbz2FromUrl(
 				this.dictionary[this.deviceType].url,
 				this.output,


### PR DESCRIPTION
- make dockerfile unpack BSP to `/tmp/jetson-flash-artifacts` directory
- add `--cache` / `-c` flag to node app command line arguments - if set, it will use already stored artifacts. Otherwise will download them from correct URL for that machine type. 

Change-type: patch