### PR TITLE
Update README for non-Docker lz4 package requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Prerequisites:
 - Sudo privileges (required by Tegra Flash and to delete intermediate steps created by the tool in `/tmp/${pid_of_process}`)
 - [NodeJS](https://nodejs.org)
 - Make sure you have python2 installed and that the `python` binary points to python2.
-- Dependencies required for the the L4T package, including: lbzip2, e2fsprogs, dosfstools, libxml2-utils
+- Dependencies required for the the L4T package, including: lbzip2, e2fsprogs, dosfstools, libxml2-utils, lz4
 
 Installation:
 


### PR DESCRIPTION
Encountered requirement for lz4c binary while flashing Seeed J2021, a Xavier NX eMMC model. This PR updates the README to add lz4 package to dependencies for non-Docker flash.

```
error: lz4c not found
To install please run:
  sudo apt-get install -y lz4
```
[transcript.txt](https://github.com/user-attachments/files/17084484/transcript.txt)
