### PR TITLE
package.json: Update node requirement to v20 or greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "publishedAt": "2024-09-23T07:56:13.752Z"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "devDependencies": {
     "tap": "^16.3.4"


### PR DESCRIPTION
Change-type: patch

Addresses https://github.com/balena-os/jetson-flash/issues/179

The warning reported in #179 is not present when issuing `npm install . ` on a host with Node v21.6.2 installed.

