### PR TITLE
package: Bump ext2fs and balena-image-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   "homepage": "https://github.com/balena-os/jetson-flash#readme",
   "dependencies": {
     "apply-patch": "^0.1.2",
-    "balena-image-fs": "^7.2.0",
+    "balena-image-fs": "^7.4.1",
     "balena-sdk": "^16.38.0",
     "bluebird": "^3.7.2",
-    "ext2fs": "^3.0.5",
+    "ext2fs": "^4.2.4",
     "file-disk": "^7.0.1",
     "fs-extra": "^9.1.0",
     "hasha": "^5.2.2",


### PR DESCRIPTION
... to bring in fix for larger preloaded images

Change-type: patch

Fixes: https://github.com/balena-os/jetson-flash/issues/194