### PR TITLE
lib/resin-jetson-flash: Update Nano eMMC and JN30B to L4T 32.7.6

### DIFF
--- a/BCT_OVERLAY_CFG/README.txt
+++ b/BCT_OVERLAY_CFG/README.txt
@@ -1,0 +1,5 @@
+1) Download https://developer.nvidia.com/downloads/embedded/L4T/r32_Release_v7.5/overlay_32.7.5_PCN211181.tbz2. From this archive extract the file "Linux_for_Tegra/bootloader/t210ref/BCT/P3448_A00_lpddr4_204Mhz_P987.cfg" and place it inside this folder.
+
+NOTE: The above is not required if you are using build.sh to run jetson-flash in a container
+
+2) Flash the device as usual using the 'jetson-nano-emmc' machine.

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,6 @@ COPY .  /usr/src/app/jetson-flash
 RUN npm install
 
 RUN wget "$bsp_url" -O "/tmp/Linux_for_Tegra.tbz2"  && tar -xvf "/tmp/Linux_for_Tegra.tbz2" -C "/tmp/" && rm /tmp/Linux_for_Tegra.tbz2
+RUN wget https://developer.nvidia.com/downloads/embedded/L4T/r32_Release_v7.5/overlay_32.7.5_PCN211181.tbz2 -O "/tmp/overlay_32.7.5_PCN211181.tbz2" && mkdir /tmp/overlay && tar xf /tmp/overlay_32.7.5_PCN211181.tbz2 -C /tmp/overlay/ && rm -rf /tmp/overlay_32.7.5_PCN211181.tbz2 && cp /tmp/overlay/Linux_for_Tegra/bootloader/t210ref/BCT/P3448_A00_lpddr4_204Mhz_P987.cfg /usr/src/app/jetson-flash/BCT_OVERLAY_CFG/ && rm -rf /tmp/overlay
 
 CMD ["./run_http_server.sh"]

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Choose your device from the list below for step-by-step instructions:
 |Device | Current L4T version |
 |-------|---------------------|
 |[Auvidea CNX100 Xavier NX](./docs/cnx100-xavier-nx.md) | L4T 32.5.1 |
-|[Auvidea JN30B Nano](./docs/jn30b-nano.md) | L4T 32.7.2  |
+|[Auvidea JN30B Nano](./docs/jn30b-nano.md) | L4T 32.7.6  |
 |[CTI Photon Nano](./docs/photon-nano.md) | L4T 32.7.3 |
 |[CTI Photon TX2 NX](./docs/photon-tx2-nx.md) | L4T 32.7.2 |
 |[CTI Photon Xavier NX](./docs/photon-xavier-nx.md) | L4T 32.7.3 |
-|[Jetson Nano eMMC](./docs/jetson-nano-emmc.md) | L4T 32.7.3 |
+|[Jetson Nano eMMC](./docs/jetson-nano-emmc.md) | L4T 32.7.6 |
 |[Jetson Nano SD-CARD Devkit](./docs/jetson-nano.md) | L4T 32.7.3 |
 |[Jetson Nano 2GB Devkit](./docs/jetson-nano-2gb-devkit.md) | L4T 32.7.1 |
 |[Jetson TX2](./docs/jetson-tx2.md) | L4T 32.7.6 |

--- a/build.sh
+++ b/build.sh
@@ -64,7 +64,7 @@ case "${DEVICE_TYPE}" in
             JETSON_FLASH_BSP_URL="https://developer.nvidia.com/embedded/l4t/r32_release_v7.1/t210/jetson-210_linux_r32.7.1_aarch64.tbz2"
             ;;
         jetson-nano-emmc)
-            JETSON_FLASH_BSP_URL="https://developer.nvidia.com/downloads/remetpack-463r32releasev73t210jetson-210linur3273aarch64tbz2"
+            JETSON_FLASH_BSP_URL="https://developer.nvidia.com/downloads/embedded/l4t/r32_release_v7.6/t210/jetson-210_linux_r32.7.6_aarch64.tbz2"
             ;;
         *)
             echo $"Using default L4T 32.7.6 BSP for Jetson TX2 ${JETSON_FLASH_BSP_URL}"

--- a/docs/jetson-nano-emmc.md
+++ b/docs/jetson-nano-emmc.md
@@ -14,8 +14,9 @@ Note that this is for the production Jetson Nano module without an SD card slot,
 
 | balenaOS version | BSP version | Jetpack version | Use this version of jetson-flash |
 |------------------|-------------|-----------------|----------------------------------|
-| 2.108.9+rev1 or later     | 32.7.3      | 4.6.3  | You are on the correct version. (v0.5.38 or later)    |
-|2.101.1 - 2.108.9 | 32.7.2      | 4.6.2           |    [v0.5.37](https://github.com/balena-os/jetson-flash/tree/v0.5.37)    |
+| 6.5.38 or later    | 32.7.6      | 4.6.6  | You are on the correct version. (v0.5.89 or later)    |
+| 2.108.9+rev1 or later     | 32.7.3      | 4.6.3  |   [v0.5.38](https://github.com/balena-os/jetson-flash/tree/v0.5.38)   |
+|2.101.1 - 2.108.9 | 32.7.2      | 4.6.2           |   [v0.5.37](https://github.com/balena-os/jetson-flash/tree/v0.5.37)    |
 | 2.95.15+rev1 -  2.101.0      | 32.7.1  | 4.6.1   |   [v0.5.28](https://github.com/balena-os/jetson-flash/tree/v0.5.28)                 |
 | 2.87.1+rev1 - 2.95.14 | 32.6.1 | 4.6             |   [v0.5.21](https://github.com/balena-os/jetson-flash/tree/v0.5.21)               |
 |2.82.11+rev2 - 2.85.2+rev5  | 32.5.1 | 4.5.1      |   [v0.5.13](https://github.com/balena-os/jetson-flash/tree/v0.5.13)       |

--- a/docs/jetson-tx2.md
+++ b/docs/jetson-tx2.md
@@ -13,7 +13,7 @@ These are the flashing instructions for the Jetson TX2. For the list of other ba
 | balenaOS version | BSP version | Jetpack version | Use this version of jetson-flash |
 |------------------|-------------|-----------------|----------------------------------|
 | 6.5.38 or later       | 32.7.6      | 4.6.6  | You are on the correct version. (v0.5.88 or later)    |
-| 2.108.9+rev1 or later       | 32.7.3      | 4.6.3  | You are on the correct version. (v0.5.35 or later)    |
+| 2.108.9+rev1 or later       | 32.7.3      | 4.6.3  | [v0.5.35](https://github.com/balena-os/jetson-flash/tree/v0.5.35)    |
 |2.101.1 - 2.108.9            | 32.7.2      | 4.6.2           |    [v0.5.34](https://github.com/balena-os/jetson-flash/tree/v0.5.34)    |
 | 2.95.15+rev1 -  2.101.0     | 32.7.1  | 4.6.1   |   [v0.5.32](https://github.com/balena-os/jetson-flash/tree/v0.5.32)                 |
 | 2.87.1+rev1 - 2.95.14       | 32.6.1 | 4.6             |   [v0.5.26](https://github.com/balena-os/jetson-flash/tree/v0.5.26)               |

--- a/docs/jn30b-nano.md
+++ b/docs/jn30b-nano.md
@@ -13,6 +13,7 @@ Note that this is for the production Jetson Nano module without an SD card slot,
 
 | balenaOS version | BSP version | Jetpack version | Use this version of jetson-flash |
 |------------------|-------------|-----------------|----------------------------------|
+|    6.5.38 or later   |   32.7.6    |    4.6.6      |  You are on the correct version. (v0.5.89 or later)  |
 |    2.103.2    |   32.7.2    |    4.6.2      |  [v0.5.37](https://github.com/balena-os/jetson-flash/tree/v0.5.37)   |
 |    2.95.8     |   32.6.1    |    4.6        |  [v0.5.21](https://github.com/balena-os/jetson-flash/tree/v0.5.21)   |
 

--- a/lib/resin-jetson-flash.js
+++ b/lib/resin-jetson-flash.js
@@ -83,7 +83,7 @@ module.exports = class ResinJetsonFlash {
 			},
 			['jetson-nano-emmc']: {
 				url:
-					'https://developer.nvidia.com/downloads/remetpack-463r32releasev73t210jetson-210linur3273aarch64tbz2',
+					'https://developer.nvidia.com/downloads/embedded/l4t/r32_release_v7.6/t210/jetson-210_linux_r32.7.6_aarch64.tbz2',
 				partitions: {
 					LNX: { path: null },
 					DTB: { path: null },
@@ -211,6 +211,16 @@ module.exports = class ResinJetsonFlash {
 			fs.closeSync(fs.openSync(workPath + '/bootloader/recovery.img', 'w'));
 			fs.writeFileSync(workPath + '/tools/ota_tools/version_upgrade/recovery_copy_binlist.txt', '');
 			fs.writeFileSync(workPath + '/tools/ota_tools/version_upgrade/ota_make_recovery_img_dtb.sh', '');
+			if ("jetson-nano-emmc" == this.deviceType.toString()) {
+				try {
+					fs.copyFileSync(path.resolve(__dirname, '../BCT_OVERLAY_CFG/P3448_A00_lpddr4_204Mhz_P987.cfg'),
+								workPath + '/bootloader/t210ref/BCT/P3448_A00_lpddr4_204Mhz_P987.cfg');
+					console.log("Replaced P3448_A00_lpddr4_204Mhz_P987.cfg in " + workPath + '/bootloader/t210ref/BCT/');
+				} catch (err) {
+					console.error(err);
+					throw new Error('Please check if the updated P3448_A00_lpddr4_204Mhz_P987.cfg has been placed in the BCT_OVERLAY_CFG directory');
+				}
+			}
 			
 			if ("jetson-agx-orin-devkit" == this.deviceType.toString()) {
 					fs.copyFileSync(path.resolve(__dirname, '../AGX_Orin/bootloader/uefi_jetson.bin'), workPath + '/bootloader/uefi_jetson.bin');


### PR DESCRIPTION
Change-type: patch

Test runs: https://github.com/balena-os/balena-jetson/pull/757