### PR TITLE
Add id-token: write permission for NPM OIDC publishing

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -14,6 +14,11 @@ on:
       - "master"
       - '20[0-9][0-9].[0-1]?[1470].x'
 
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
 jobs:
   flowzone:
     name: Flowzone


### PR DESCRIPTION
Add `id-token: write` permission to enable NPM publishing via OIDC trusted publishers.
Include `contents: read` and `packages: read` to preserve org default permissions.

Connects-to: https://balena.fibery.io/Work/Improvement/3782

Change-type: patch