### PR TITLE
Mark package as private to prevent npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
   },
   "devDependencies": {
     "tap": "^16.3.4"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
This package should not be published to npm. Adding `"private": true` to package.json prevents accidental publishing.

Change-type: patch