### PR TITLE
Add Renovate config extending balena-io/renovate-config

### DIFF
--- a/.github/workflows/renovate.json
+++ b/.github/workflows/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>balena-io/renovate-config"
+  ]
+}


### PR DESCRIPTION
Avoids enforcing Changelog-entry footers on this repo

See: https://balena.fibery.io/Work/Improvement/Non-yocto-device-repos-in-balena-os-should-extend-balena-io-renovate-config-4694